### PR TITLE
doc addition about modifying @ISA after extends

### DIFF
--- a/lib/MooseX/NonMoose.pm
+++ b/lib/MooseX/NonMoose.pm
@@ -101,6 +101,11 @@ any class. For globref-based classes in particular, L<MooseX::GlobRef> will
 also allow Moose to work. For more information, see the C<032-moosex-insideout>
 and C<033-moosex-globref> tests bundled with this dist.
 
+=item * Modifying your class' C<@ISA> after an intial C<extends> call will potentially
+cause problems if any of those new entries in the C<@ISA> override the constructor.
+C<MooseX::NonMoose> wraps the nearest C<new()> method at the time C<extends>
+is called and will not see any other C<new()> methods in the @ISA hierarchy.
+
 =item * Completely overriding the constructor in a class using
 C<MooseX::NonMoose> (i.e. using C<sub new { ... }>) currently doesn't work,
 although using method modifiers on the constructor should work identically to


### PR DESCRIPTION
Feel free to modify but I thought I would submit a suggestion at least.  Basically, the problem is seen when you have code that modifies the class' @ISA after an 'extends' call.  For instance, in DBIx::Class:

```
package My::Schema::Result::SomeTable;
use Moose;
use MooseX::NonMoose;
extends 'DBIx::Class::Core';
__PACKAGE__->load_components('SomeComponentThatOverridesNew'); # modifies @ISA

# later
My::Schema::Result::SomeTable->new({}); # never calls SomeComponentThatOverridesNew::new()
```

MX::NonMoose grabs the nearest new() method at "extends" time so any other "new" methods prepended to the @ISA chain would be ignored.
