### PR TITLE
Added "use Try::Tiny" to fix Try::Tiny not being included as dependency

### DIFF
--- a/lib/MooseX/NonMoose/Meta/Role/Class.pm
+++ b/lib/MooseX/NonMoose/Meta/Role/Class.pm
@@ -4,6 +4,7 @@ use Moose::Role;
 
 use List::MoreUtils qw(any);
 use Module::Runtime qw(use_package_optimistically);
+use Try::Tiny;
 
 =head1 SYNOPSIS
 


### PR DESCRIPTION
We had an issue with a broken Moose install on one of our machines (for some reason none of its dependencies were installed).  However when we were trying to install MooseX::NonMoose it was failing the tests due to Try::Tiny not being in the dependencies yet being called cirectly in one of the modules.  Adding a "use Try::Tiny" fixes this and allows dzils AutoPrereqs to pick up ther requirement.
