### PR TITLE
protect against installed Foo module

### DIFF
--- a/t/extends-version.t
+++ b/t/extends-version.t
@@ -5,6 +5,7 @@ use Test::More;
 use Test::Fatal;
 
 {
+    $INC{'Foo.pm'} = __FILE__;
     package Foo;
     our $VERSION = '0.02';
     sub new { bless {}, shift }


### PR DESCRIPTION
If there is a 'Foo' module available elsewhere in @INC, it will be loaded and its $VERSION will overwrite the one specified in the test.
