### PR TITLE
Don't execute undef superclass destructor

### DIFF
--- a/lib/MooseX/NonMoose/Meta/Role/Class.pm
+++ b/lib/MooseX/NonMoose/Meta/Role/Class.pm
@@ -237,7 +237,7 @@ sub _check_superclass_destructor {
         local $?;
 
         Try::Tiny::try {
-            $super_DESTROY->execute($self);
+            $super_DESTROY->execute($self) if defined $super_DESTROY;
             $self->DEMOLISHALL(Devel::GlobalDestruction::in_global_destruction);
         }
         Try::Tiny::catch {


### PR DESCRIPTION
During global destruction, $super_DESTROY is sometimes undef resulting in errors like:

Can't call method "execute" on an undefined value at MooseX/Meta/Role/Class.pm line 240 during global destruction.

so don't do that unless $super_DESTROY is still defined (per Tom Christiansen, "Global destruction order is vehemently not guaranteed").